### PR TITLE
Added certain reset rules from HTML5 boilerplate

### DIFF
--- a/assets/sass/modules/_reset.scss
+++ b/assets/sass/modules/_reset.scss
@@ -14,11 +14,6 @@
     }
 }
 
-textarea{
-    resize: vertical;
-}
-
-
 /*
  * Remove the gap between audio, canvas, iframes,
  * images, videos and the bottom of their containers:


### PR DESCRIPTION
Restrict textarea from resizing horizontally which can make the page look messy and remove the gap between elements and the bottom of their containers as found within HTML5 Boilerplate.
